### PR TITLE
feat: add compactPrint option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiqqe/lambda-logger",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Logger for AWS Lambda nodejs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 # A nodejs logger for AWS Lambda
 
 - Writes logs to stdout/stderr using console.debug|info|warn|error
-- Logs in JSON format
+- Logs in JSON format (supports both pretty-printed and compact formats)
 - Supports log levels: DEBUG, INFO, WARN, ERROR and OFF
 - Defaults to log level INFO
 - Built using typescript and includes types
@@ -12,7 +12,7 @@
 
 ```typescript
 import { APIGatewayEvent } from 'aws-lambda';
-import { log } from '@tiqqe/lambda-logger';
+import { log, LogLevels } from '@tiqqe/lambda-logger';
 
 export const healthCheck = async (event: APIGatewayEvent) => {
   // A standard INFO log message
@@ -36,7 +36,7 @@ To show debug messages you need to explicitly set the log.level to DEBUG like th
 
 ```typescript
 // Set loglevel
-log.level = LogLevels.DEBUG;
+log.logLevel = LogLevels.DEBUG;
 // Write debug log
 log.debug('Debugging stuff');
 ```
@@ -45,7 +45,7 @@ log.debug('Debugging stuff');
 {
   "timestamp": "2020-03-26T14:36:07.345Z",
   "logLevel": "DEBUG",
-  "message": "Message",
+  "message": "Debugging stuff"
 }
 ```
 
@@ -84,6 +84,29 @@ You can easily set the initial log level by setting the environment variable `LO
 
 ```yml
 LOG_LEVEL: 'DEBUG'
+```
+
+## Compact JSON output
+
+By default, logs are pretty-printed for better readability. You can enable compact single-line output by setting the `compactPrint` option:
+
+```typescript
+// Enable compact printing
+log.init({ compactPrint: true });
+
+log.info('My message');
+// Output: {"timestamp":"2024-02-13T14:36:07.345Z","logLevel":"INFO","message":"My message"}
+
+// Default pretty printing
+log.init({ compactPrint: false });
+
+log.info('My message');
+// Output:
+// {
+//   "timestamp": "2024-02-13T14:36:07.345Z",
+//   "logLevel": "INFO",
+//   "message": "My message"
+// }
 ```
 
 ## Release process

--- a/src/types/LogOptions.ts
+++ b/src/types/LogOptions.ts
@@ -1,7 +1,6 @@
 import { LogLevels } from './logLevels';
 
 export interface LogOptions {
-
   /**
    * This governs which logs will be written. If log level is
    * INFO all logs with INFO and above will be written. So: INFO
@@ -15,4 +14,9 @@ export interface LogOptions {
    * This allows tracking of "events" through multiple distributed services.
    */
   correlationId?: string;
+
+  /**
+   * If true (default is false), the log will be printed in a compact format.
+   */
+  compactPrint?: boolean;
 }


### PR DESCRIPTION
Add a `compactPrint` option to fix multi-line printing issues with CloudWatch when using the logger in AWS ECS Fargate.