### PR TITLE
Support for BigInt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2024-02-28
+
+### Added
+
+- Support for serializing BigInt via the option `supportBigInt`
+
+
 ## [1.0.0] - 2024-02-13
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -20,21 +20,20 @@
   "author": "TIQQE",
   "license": "ISC",
   "homepage": "https://github.com/TIQQE/tq-lambda-logger#readme",
-  "dependencies": {},
   "devDependencies": {
     "@types/aws-lambda": "^8.10.147",
     "@types/chai": "^5.0.1",
     "@types/json-stringify-safe": "^5.0.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
     "chai": "^5.1.2",
+    "eslint": "^8.57.0",
     "mocha": "^11.1.0",
     "nyc": "^17.1.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^7.0.1",
-    "@typescript-eslint/eslint-plugin": "^7.0.1"
+    "typescript": "^5.7.3"
   },
   "nyc": {
     "extension": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiqqe/lambda-logger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Logger for AWS Lambda nodejs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,25 @@ log.info('My message');
 // }
 ```
 
+## Serialize BigInt
+
+By default JSON.stringify will raise a `TypeError` if an object contains values of the type [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt). By setting the `supportBigInt`option to `true` they will be serialized to a string + "n". Example `BigInt(123)` -> `"123n"`.
+
+```typescript
+// Enable support for BigInt
+log.init({ supportBigInt: true });
+
+log.info([message: "BigInt supported", bigIntValue: 123n});
+// Output:
+// {
+//   "timestamp": "2025-02-17T14:36:07.345Z",
+//   "logLevel": "INFO",
+//   "Message": "BigInt supported"
+//   "bigIntValue": "123n"
+// }
+
+
+
 ## Release process
 
 Bump the `version` in `package.json` according to [semver](https://semver.org/spec/v2.0.0.html). If we are making a non-breaking change, compared to the last version, the new `version` would go from `0.11.0` to `0.12.0`.

--- a/src/bigIntReplacer.ts
+++ b/src/bigIntReplacer.ts
@@ -1,0 +1,11 @@
+// Stringify BigInt using the replacer
+// const jsonBigInteger = JSON.stringify(bigInteger, bigIntReplacer);
+// Parse from JSON
+// const fromJsonBigInteger = JSON.parse(jsonBigInteger, bigIntReviver);
+
+export function bigIntReplacer(_key: string, value: any): any {
+  if (typeof value === 'bigint') {
+    return value.toString() + 'n';
+  }
+  return value;
+}

--- a/src/types/LogOptions.ts
+++ b/src/types/LogOptions.ts
@@ -22,4 +22,10 @@ export interface LogOptions {
    * @default false
    */
   compactPrint?: boolean;
+
+  /**
+   * If true (default is false), BigInt values will be serialized as a string + "n". Example BigInt(123) -> "123n"
+   * @default false
+   */
+  supportBigInt?: boolean;
 }

--- a/test/bigIntReplacer.spec.ts
+++ b/test/bigIntReplacer.spec.ts
@@ -1,0 +1,60 @@
+import { assert } from 'chai';
+import { bigIntReplacer } from '../src/bigIntReplacer';
+
+describe('bigIntReplacer', () => {
+  it('should convert BigInt to string with "n" suffix', () => {
+    // Test with small BigInt value
+    const smallBigInt = BigInt(123);
+    assert.equal(bigIntReplacer('test', smallBigInt), '123n', 'Should convert small BigInt to string with "n" suffix');
+
+    // Test with large BigInt value
+    const largeBigInt = BigInt('9007199254740991');
+    assert.equal(
+      bigIntReplacer('test', largeBigInt),
+      '9007199254740991n',
+      'Should convert large BigInt to string with "n" suffix'
+    );
+
+    // Test with negative BigInt
+    const negativeBigInt = BigInt(-42);
+    assert.equal(
+      bigIntReplacer('test', negativeBigInt),
+      '-42n',
+      'Should convert negative BigInt to string with "n" suffix'
+    );
+  });
+
+  it('should return non-BigInt values unchanged', () => {
+    // Test with string
+    assert.equal(bigIntReplacer('test', 'hello'), 'hello', 'Should return strings unchanged');
+
+    // Test with number
+    assert.equal(bigIntReplacer('test', 42), 42, 'Should return numbers unchanged');
+
+    // Test with null
+    assert.equal(bigIntReplacer('test', null), null, 'Should return null unchanged');
+
+    // Test with object
+    const obj = { foo: 'bar' };
+    assert.deepEqual(bigIntReplacer('test', obj), obj, 'Should return objects unchanged');
+
+    // Test with array
+    const arr = [1, 2, 3];
+    assert.deepEqual(bigIntReplacer('test', arr), arr, 'Should return arrays unchanged');
+  });
+
+  it('should correctly handle BigInt in nested objects when used with JSON.stringify', () => {
+    const testObj = {
+      regular: 42,
+      big: BigInt(9007199254740991),
+      nested: {
+        big: BigInt(123),
+      },
+    };
+
+    const serialized = JSON.stringify(testObj, bigIntReplacer);
+    const expected = '{"regular":42,"big":"9007199254740991n","nested":{"big":"123n"}}';
+
+    assert.equal(serialized, expected, 'Should correctly replace BigInt in nested objects');
+  });
+});


### PR DESCRIPTION
JSON.stringify raises a TypeError if an object contains the type BigInt. When working in a project that uses BigInt this adds an extra layer of complexity to use the logger.

This change adds an supportBigInt option that makes the logger serialize BigInt(123) to "123n".

readme, changelog, version in package.json has been updated. Code is 100% covered by unit tests.