### PR TITLE
fix: set log level to initial state when not passed into init()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-05-28
+
+### Fixed
+
+- Fixed an issue where `init()` would set `LogLevel` to `INFO` instead of its initial value.
+
 ## [1.1.0] - 2024-02-28
 
 ### Added
 
 - Support for serializing BigInt via the option `supportBigInt`
-
 
 ## [1.0.0] - 2024-02-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiqqe/lambda-logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Logger for AWS Lambda nodejs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,9 @@
+import { bigIntReplacer } from './bigIntReplacer';
 import { LogInput } from './types/LogInput';
 import { LogInputError } from './types/LogInputError';
 import { LogLevels } from './types/logLevels';
 import { LogOptions } from './types/LogOptions';
 import { LogOutput } from './types/LogOutput';
-import { bigIntReplacer } from './bigIntReplacer';
 
 /**
  * Provides methods for writing logs to in different log-levels. Logs are written in JSON format to stdout using console.log().
@@ -46,7 +46,7 @@ class Logger {
    * logger options to their initial state.
    */
   public init(options: LogOptions) {
-    this.logLevel = options.logLevel ?? LogLevels.INFO;
+    this.logLevel = options.logLevel ?? this.logLevel;
     this.correlationId = options.correlationId ?? undefined;
     this.compactPrint = options.compactPrint ?? false;
     this.supportBigInt = options.supportBigInt ?? false;
@@ -182,4 +182,4 @@ class Logger {
 
 const log = new Logger();
 
-export { log, LogLevels, LogInput, LogOutput };
+export { log, LogInput, LogLevels, LogOutput };


### PR DESCRIPTION
Problem: when calling `init()` with no option for logLevel, it is set to INFO, not the initialization value.

Solution: use the initial value instead.