### PR TITLE
feat: add useStdout option to bypass Lambda console wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-06
+
+### Added
+
+- `useStdout` option to write JSON directly to `process.stdout`, bypassing Lambda's console wrapper which prepends a tab-delimited header that breaks downstream JSON consumers
+
 ## [1.1.1] - 2025-05-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiqqe/lambda-logger",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiqqe/lambda-logger",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "ISC",
       "devDependencies": {
         "@types/aws-lambda": "^8.10.147",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiqqe/lambda-logger",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Logger for AWS Lambda nodejs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -41,6 +41,13 @@ class Logger {
   public supportBigInt: boolean = false;
 
   /**
+   * If true, write JSON directly to process.stdout instead of using console methods.
+   * This avoids Lambda TEXT mode's tab-delimited prefix, producing clean JSON.
+   * @default false
+   */
+  public useStdout: boolean = false;
+
+  /**
    * Setup the meta data that will be added to all logs.
    * Calling init with no/missing options will reset the
    * logger options to their initial state.
@@ -50,6 +57,7 @@ class Logger {
     this.correlationId = options.correlationId ?? undefined;
     this.compactPrint = options.compactPrint ?? false;
     this.supportBigInt = options.supportBigInt ?? false;
+    this.useStdout = options.useStdout ?? false;
   }
 
   /**
@@ -93,14 +101,14 @@ class Logger {
     }
     if (logLevel >= this.logLevel) {
       const log = this.createLogJson(logInput, logLevel);
-      // Call the appropriate console logging function with the serialized log object
-      // When supportBigInt is true, bigIntReplacer is used to properly serialize BigInt values
-      // When compactPrint is true, the JSON is output without indentation, otherwise with 2-space indentation
-      logFunction(
-        this.compactPrint
-          ? JSON.stringify(log, this.supportBigInt ? bigIntReplacer : undefined)
-          : JSON.stringify(log, this.supportBigInt ? bigIntReplacer : undefined, 2)
-      );
+      const json = this.compactPrint
+        ? JSON.stringify(log, this.supportBigInt ? bigIntReplacer : undefined)
+        : JSON.stringify(log, this.supportBigInt ? bigIntReplacer : undefined, 2);
+      if (this.useStdout) {
+        process.stdout.write(json + '\n');
+      } else {
+        logFunction(json);
+      }
     }
   }
 

--- a/src/types/LogOptions.ts
+++ b/src/types/LogOptions.ts
@@ -28,4 +28,13 @@ export interface LogOptions {
    * @default false
    */
   supportBigInt?: boolean;
+
+  /**
+   * If true (default is false), write JSON directly to process.stdout instead of
+   * using console methods. This avoids Lambda TEXT mode's tab-delimited prefix
+   * (TIMESTAMP\tREQUEST_ID\tLEVEL\t), producing clean JSON that log consumers
+   * and CloudWatch subscription filters can parse directly.
+   * @default false
+   */
+  useStdout?: boolean;
 }


### PR DESCRIPTION
## Problem

Lambda TEXT mode monkey-patches `console.*` methods and prepends a tab-delimited header (`TIMESTAMP\tREQUEST_ID\tLEVEL\t`) to every log line. This makes the JSON output unparseable for downstream consumers (like `log-sniffer-map-alert`) that expect log messages to start with `{`.

## Solution

Add a `useStdout` option that writes JSON directly to `process.stdout` instead of using `console.*` methods. This bypasses Lambda's console wrapper, producing clean JSON.

```typescript
log.init({ useStdout: true });
```

## Non-breaking

Defaults to `false`, preserving existing behavior for all current consumers.

## Changes

- `LogOptions.ts`: add `useStdout?: boolean` option
- `logger.ts`: add `useStdout` property, route output through `process.stdout.write` when enabled