### PR TITLE
ci: separate build and publish jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,17 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [22.x]
-
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -19,6 +21,18 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm test
+      - run: npm run build
+
+  publish:
+    needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm install
       - run: npm run build
       - uses: JS-DevTools/npm-publish@v3
         with:


### PR DESCRIPTION
## Summary

- Build job runs on all pushes and PRs to master (lint, test, build)
- Publish job only runs on push to master, after build passes
- Prevents failed npm publish attempts on PR branches

## Test plan

- CI on this PR should only run the build job (no publish)
- After merge, push to master triggers both build and publish